### PR TITLE
Make copy/paste code copy-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,30 @@ which can be executed in the address bar as
  As a security measure Chrome will not let you paste a string starting with "javascript:" so that people don't unintentionally execute code. Therefore, do the following
  
 1. type the letter **`j`**
-2.  then paste the following: **`avascript:fetch(location.href).then(r=>r.text()).then(r=>document.body.outerHTML=r)`**
+2.  then paste the following:
+
+```
+avascript:fetch(location.href).then(r=>r.text()).then(r=>document.body.outerHTML=r)
+```
+
 3. Press `Enter`
 		
 ###  Using Developer Console
 1.  Open the developer console `Ctrl+Shift+i` in Google Chrome or Microsoft Edge
 2. Click on the `Console` tab if not already selected
-3. Paste the following `fetch(location.href).then(r=>r.text()).then(r=>document.body.outerHTML=r)`
+3. Paste the following:
+```
+fetch(location.href).then(r=>r.text()).then(r=>document.body.outerHTML=r)
+```
 4. Press `Enter`
 
 ### Using Bookmarks Bar
 1. Navigate to Bookmarks Manager `Ctrl+Shift+O`
 2. Click options menu on top right of screen and select "Add New Bookmark"
-3. Add bookwark with the url as 
-	`javascript:fetch(location.href).then(r=>r.text()).then(r=>document.body.outerHTML=r)`
+3. Add bookwark with the url as:
+```
+javascript:fetch(location.href).then(r=>r.text()).then(r=>document.body.outerHTML=r)
+```
 
 4. Click this bookmark to bypass soft paywalls
 


### PR DESCRIPTION
Previously, the user needed to manually highlight the bits of code to copy/paste, but github gives us an easy copy button if we use the multi-line code format.